### PR TITLE
Added browser cache implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,12 +67,12 @@ function loadHelpers (dirs) {
 
 function Jade () {
   var defaultOptions = {
-    compileDebug: false,
-    pretty: false
-  }
-  , globalNoCache = false
-  , compilers = new Map()
-  , defaultLocals, viewPath
+        compileDebug: false,
+        pretty: false
+      }
+    , globalNoCache = false
+    , compilers = new Map()
+    , defaultLocals, viewPath
 
   this.version = pkg.version
 
@@ -93,7 +93,7 @@ function Jade () {
          * @param {Object}  options options that pass to Jade compiler, merged with global default options
          * @param {Boolean} noCache use cache or not
          */
-         return function* (tpl, locals, options, noCache) {
+        return function* (tpl, locals, options, noCache) {
           var compileOptions, tplPath, rawJade, compiler, skipCache
 
           tplPath = path.join(viewPath, /\.jade$/.test(tpl) ? tpl : tpl + '.jade')
@@ -121,7 +121,7 @@ function Jade () {
             }
           }
 
-          if (!skipCache && this.request.header['if-modified-since']){
+          if (!skipCache){
             var lastModified = new Date(fs.statSync(tplPath).mtime)
             var ifModifiedSince = new Date(this.request.header['if-modified-since'])
             var notModified = Math.floor(+ifModifiedSince/1000/60) >= Math.floor(+lastModified/1000/60)


### PR DESCRIPTION
If caching is enabled, koa-jade now checks to see if the file has been modified since the last date the request sends over. 

If it has been, it will send back a new modified date and use the compiler as expected. If it hasn't, it will send back a 304 response, prompting the browser to use whatever is in cache.