### PR TITLE
Fix default locals

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,8 @@ function Jade () {
       }
     , globalNoCache = false
     , compilers = new Map()
-    , defaultLocals, viewPath
+    , defaultLocals = {}
+    , viewPath
 
   this.version = pkg.version
 


### PR DESCRIPTION
If no `locals` option is specified in `jade.middleware`, `defaultLocals` can be `undefined` and helpers are not loaded.